### PR TITLE
Curation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -1,6 +1,7 @@
 name: Curation Issue Template
 description: Start a variant curation issue.
 title: "[chr:pos][variant type][short description]"
+projects: ["genome-in-a-bottle/1"]
 assignees:
   - Faizal-Eeman
 body:

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -12,9 +12,9 @@ body:
       description: Tumor/Normal dataset used for variant calling
       multiple: true
       options:
-        - HG008-N-P and HG008-T Passage 23
-        - HG008-N-D and HG008-T Passage 23
-        - HG008-N-P and HG008-T Spring 22 Passage 36
+        - HG008-T Passage 23 vs HG008-N-P
+        - HG008-T Passage 23 vs HG008-N-D
+        - HG008-T Spring 22 Passage 36 vs HG008-N-P
         - HG008-N-P normal only
         - HG008-N-D normal only
         - HG008-T Passage 23 tumor only

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -43,6 +43,14 @@ body:
         - Karyologic karyotyping
     validations:
       required: true
+  - type: input
+    id: variant-type
+    attributes:
+      label: Variant Type
+      placeholder: |
+        SNV or INDEL
+        SV - Inversion, Translocation, etc.
+        CNA - Deletion, Duplication, LOH, etc.
   - type: textarea
     id: variant-caller
     attributes:

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -41,8 +41,8 @@ body:
         - Bionano Optical Mapping
         - Arima and Phase Genomics HiC - Illumina
         - Karyologic karyotyping
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     id: variant-caller
     attributes:

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -1,9 +1,8 @@
 name: Curation Issue Template
 description: Start a variant curation issue.
 title: "[chr:pos][variant type][short description]"
-projects: #["project_name"] project should be enabled in the repo by admin
-assigness:
-  - jzook
+assignees:
+  - Faizal-Eeman
 body:
   - type: dropdown
     id: dataset
@@ -27,7 +26,7 @@ body:
       label: Sequencing Technology
       description: Select all that apply
       multiple: true
-      option:
+      options:
         - Illumina WGS
         - Element - AVITI - short insert - (~350bp)
         - Element - AVITI - long insert (1000+ bp)

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -55,7 +55,7 @@ body:
     attributes:
       label: Variant Details
       description: Provide variant details
-      placeholder: chr:position\n ID:\n Ref:\n Alt:\n Please include INFO and FORMAT fields in separate lines\n AD:\n DP:\n etc.re
+      placeholder: chr:position/\n ID:\n Ref:\n Alt:\n Please include INFO and FORMAT fields in separate lines\n AD:\n DP:\n etc.re
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -55,7 +55,15 @@ body:
     attributes:
       label: Variant Details
       description: Provide variant details
-      placeholder: chr:position/\n ID:\n Ref:\n Alt:\n Please include INFO and FORMAT fields in separate lines\n AD:\n DP:\n etc.re
+      placeholder: |
+        chr:position
+        ID:
+        Ref:
+        Alt:
+        Please include INFO and FORMAT fields in separate lines
+        AD:
+        DP:
+        etc.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -1,0 +1,53 @@
+name: Curation Issue Template
+description: Start a variant curation issue.
+title: "[chr:pos][variant type][short description]"
+projects: #["project_name"] project should be enabled in the repo by admin
+assigness:
+  - jzook
+body:
+  - type: dropdown
+    id: dataset
+    attributes:
+      label: Tumor/Normal dataset
+      description: Tumor/Normal dataset used for variant calling
+      multiple: true
+      options:
+        - HG008-N-P and HG008-T Passage 23
+        - HG008-N-D and HG008-T Passage 23
+        - HG008-N-P and HG008-T Spring 22 Passage 36
+        - HG008-N-P normal only
+        - HG008-N-D normal only
+        - HG008-T Passage 23 tumor only
+        - HG008-T Spring 22 Passage 36 tumor only
+    validations:
+      required: true
+  - type: dropdown
+    id: technology
+    attributes:
+      label: Sequencing Technology
+      description: Select all that apply
+      multiple: true
+      option:
+        - Illumina WGS
+        - Element - AVITI - short insert - (~350bp)
+        - Element - AVITI - long insert (1000+ bp)
+        - PacBio Onso
+        - Ultima UG100
+        - BioSkryb single-cell WGS - Illumina
+        - BioSkryb single-cell WGS - Ultima
+        - Oxford Nanopore Technologies (UL)
+        - Oxforn Nanopore Technologies (duplex)
+        - Oxforn Nanopore Technologies (std)
+        - PacBio HiFi (Revio)
+        - Bionano Optical Mapping
+        - Arima and Phase Genomics HiC - Illumina
+        - Karyologic karyotyping
+      validations:
+        required: true
+  - type: textarea
+    id: variant-caller
+    attributes:
+      label: Variant Caller(s)
+      description: Variant callers used for variant calling
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -3,7 +3,7 @@ description: Start a variant curation issue.
 title: "[chr:pos][variant type][short description]"
 projects: ["genome-in-a-bottle/1"]
 assignees:
-  - Faizal-Eeman
+  - jzook
 body:
   - type: dropdown
     id: dataset

--- a/.github/ISSUE_TEMPLATE/curation_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/curation_issue_template.yml
@@ -50,3 +50,18 @@ body:
       description: Variant callers used for variant calling
     validations:
       required: true
+  - type: textarea
+    id: variant-detail
+    attributes:
+      label: Variant Details
+      description: Provide variant details
+      placeholder: chr:position\n ID:\n Ref:\n Alt:\n Please include INFO and FORMAT fields in separate lines\n AD:\n DP:\n etc.re
+    validations:
+      required: true
+  - type: textarea
+    id: visualization
+    attributes:
+      label: Visualization
+      description: Add IGV snapshots or any relevant plots
+    validations:
+      required: true


### PR DESCRIPTION
Adding a template to allow future variant curation in a standard format.

Template preview - https://github.com/Faizal-Eeman/HG008-curations/blob/curation-issue-template/.github/ISSUE_TEMPLATE/curation_issue_template.yml

The curation issue template title will have a standard format to enhance readability and accessibility of the all curations.
`[chr:pos][variant type][short description]`

The repo admin can enable auto labelling of issues based on `[variant type]` keyword.

The template body contains all details required by the curator to validate a variant.

@jzook let me know what you think of this template!